### PR TITLE
Fix #40: Add a health check

### DIFF
--- a/cmd/ct-fetch/ct-fetch.go
+++ b/cmd/ct-fetch/ct-fetch.go
@@ -557,7 +557,7 @@ func main() {
 
 		healthServer := &http.Server{
 			Handler: healthHandler,
-			Addr:    ":8080",
+			Addr:    *ctconfig.HealthAddr,
 		}
 		go func() {
 			err := healthServer.ListenAndServe()

--- a/cmd/ct-fetch/ct-fetch.go
+++ b/cmd/ct-fetch/ct-fetch.go
@@ -539,15 +539,16 @@ func main() {
 		healthHandler := http.NewServeMux()
 		healthHandler.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 			duration := time.Since(syncEngine.ApproximateMostRecentUpdateTimestamp())
-			if duration.Minutes() > 10 {
+			evaluationTime := 2 * pollingDelayMean
+			if duration > evaluationTime {
 				w.WriteHeader(500)
-				_, err := w.Write([]byte(fmt.Sprintf("error: %v since last update", duration)))
+				_, err := w.Write([]byte(fmt.Sprintf("error: %v since last update, which is longer than 2 * pollingDelayMean (%v)", duration, evaluationTime)))
 				if err != nil {
 					glog.Warningf("Couldn't return poor health status: %+v", err)
 				}
 			} else {
 				w.WriteHeader(200)
-				_, err := w.Write([]byte(fmt.Sprintf("ok: %v since last update", duration)))
+				_, err := w.Write([]byte(fmt.Sprintf("ok: %v since last update, which is shorter than 2 * pollingDelayMean (%v)", duration, evaluationTime)))
 				if err != nil {
 					glog.Warningf("Couldn't return ok health status: %+v", err)
 				}

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type CTConfig struct {
 	OutputRefreshPeriod *string
 	Config              *string
 	StackdriverMetrics  *bool
+	HealthAddr          *string
 }
 
 func confInt(p *int, section *ini.Section, key string, def int) {
@@ -132,6 +133,7 @@ func NewCTConfig() *CTConfig {
 		CertPath:            new(string),
 		GoogleProjectId:     new(string),
 		StackdriverMetrics:  new(bool),
+		HealthAddr:          new(string),
 		RedisHost:           new(string),
 		RedisTimeout:        new(string),
 		SavePeriod:          new(string),
@@ -194,6 +196,7 @@ func (c *CTConfig) Init() {
 	confString(c.OutputRefreshPeriod, section, "outputRefreshPeriod", "125ms")
 	confString(c.StatsRefreshPeriod, section, "statsRefreshPeriod", "10m")
 	confBool(c.StackdriverMetrics, section, "stackdriverMetrics", false)
+	confString(c.HealthAddr, section, "healthAddr", ":8080")
 
 	// Finally, CLI flags override
 	if flagOffset > 0 {
@@ -233,4 +236,5 @@ func (c *CTConfig) Usage() {
 	fmt.Println("statsRefreshPeriod = Period between stats being dumped to stderr")
 	fmt.Println("stackdriverMetrics = true if should log to StackDriver, requires googleProjectId")
 	fmt.Println("redisTimeout = Timeout for operations from Redis, e.g. 10s")
+	fmt.Println("healthAddr = Address to host the /health information http endpoint, e.g. localhost:8080")
 }

--- a/storage/filesystemdatabase.go
+++ b/storage/filesystemdatabase.go
@@ -138,6 +138,15 @@ func (db *FilesystemDatabase) GetLogState(aUrl *url.URL) (*CertificateLog, error
 	}, nil
 }
 
+func (db *FilesystemDatabase) GetAllLogStates() []*CertificateLog {
+	logs, cacheErr := db.extCache.GetAllLogStates()
+	if cacheErr != nil {
+		glog.Warningf("Unable to get all logs: %+v", cacheErr)
+		return []*CertificateLog{}
+	}
+	return logs
+}
+
 func (db *FilesystemDatabase) markDirty(aExpiration *time.Time) error {
 	subdirName := aExpiration.Format(kExpirationFormat)
 	return db.backend.MarkDirty(subdirName)

--- a/storage/filesystemdatabase_test.go
+++ b/storage/filesystemdatabase_test.go
@@ -330,6 +330,11 @@ func test_LogState(t *testing.T, cache RemoteCache, storageDB CertDatabase) {
 	if updatedLog.MaxEntry != 9 || !updatedLog.LastEntryTime.IsZero() {
 		t.Errorf("Expected the MaxEntry to be 9 %s", updatedLog.String())
 	}
+
+	logList := storageDB.GetAllLogStates()
+	if len(logList) != 1 {
+		t.Errorf("Expected one entry in the log list: %+v", logList)
+	}
 }
 
 func Test_LogStateFirestoreBackend(t *testing.T) {

--- a/storage/mockcache.go
+++ b/storage/mockcache.go
@@ -13,6 +13,7 @@ import (
 
 type MockRemoteCache struct {
 	Data        map[string][]string
+	LogData     map[string][]string
 	Expirations map[string]time.Time
 	Duplicate   int
 }
@@ -20,6 +21,7 @@ type MockRemoteCache struct {
 func NewMockRemoteCache() *MockRemoteCache {
 	return &MockRemoteCache{
 		Data:        make(map[string][]string),
+		LogData:     make(map[string][]string),
 		Expirations: make(map[string]time.Time),
 		Duplicate:   0,
 	}
@@ -199,12 +201,12 @@ func (ec *MockRemoteCache) StoreLogState(log *CertificateLog) error {
 		return err
 	}
 
-	ec.Data[log.ShortURL] = []string{string(encoded)}
+	ec.LogData[log.ShortURL] = []string{string(encoded)}
 	return nil
 }
 
 func (ec *MockRemoteCache) LoadLogState(shortUrl string) (*CertificateLog, error) {
-	data, ok := ec.Data[shortUrl]
+	data, ok := ec.LogData[shortUrl]
 	if !ok {
 		return nil, fmt.Errorf("Log state not found")
 	}
@@ -217,4 +219,16 @@ func (ec *MockRemoteCache) LoadLogState(shortUrl string) (*CertificateLog, error
 		return nil, err
 	}
 	return &log, nil
+}
+
+func (ec *MockRemoteCache) GetAllLogStates() ([]*CertificateLog, error) {
+	objects := []*CertificateLog{}
+	for key := range ec.LogData {
+		state, err := ec.LoadLogState(key)
+		if err != nil {
+			return objects, err
+		}
+		objects = append(objects, state)
+	}
+	return objects, nil
 }

--- a/storage/rediscache.go
+++ b/storage/rediscache.go
@@ -13,6 +13,7 @@ import (
 
 const EMPTY_QUEUE string = "redis: nil"
 const NO_EXPIRATION time.Duration = 0
+const LOG_PREFIX string = "log::"
 
 type RedisCache struct {
 	client *redis.Client
@@ -178,7 +179,7 @@ func (rc *RedisCache) TrySet(k string, v string, life time.Duration) (string, er
 }
 
 func shortUrlToLogKey(shortUrl string) string {
-	return fmt.Sprintf("log::%s", shortUrl)
+	return LOG_PREFIX + shortUrl
 }
 
 func (ec *RedisCache) StoreLogState(log *CertificateLog) error {
@@ -201,4 +202,26 @@ func (ec *RedisCache) LoadLogState(shortUrl string) (*CertificateLog, error) {
 		return nil, err
 	}
 	return &log, nil
+}
+
+func (ec *RedisCache) GetAllLogStates() ([]*CertificateLog, error) {
+	logList := []*CertificateLog{}
+	scanres := ec.client.Scan(0, shortUrlToLogKey("*"), 0)
+	err := scanres.Err()
+	if err != nil {
+		return logList, err
+	}
+
+	iter := scanres.Iterator()
+
+	for iter.Next() {
+		keyName := iter.Val()
+		obj, err := ec.LoadLogState(strings.TrimPrefix(keyName, LOG_PREFIX))
+		if err != nil {
+			return logList, err
+		}
+		logList = append(logList, obj)
+	}
+
+	return logList, iter.Err()
 }

--- a/storage/rediscache_test.go
+++ b/storage/rediscache_test.go
@@ -463,7 +463,12 @@ func TestRedisLogState(t *testing.T) {
 
 	expectNilLogState(t, rc, log.ShortURL)
 
-	err := rc.StoreLogState(log)
+	originalList, err := rc.GetAllLogStates()
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = rc.StoreLogState(log)
 	if err != nil {
 		t.Error(err)
 	}
@@ -483,7 +488,7 @@ func TestRedisLogState(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if len(list) != 1 {
-		t.Errorf("Expected 1 log state: %+v", list)
+	if len(list) != 1+len(originalList) {
+		t.Errorf("Expected 1 new log state: %+v", list)
 	}
 }

--- a/storage/rediscache_test.go
+++ b/storage/rediscache_test.go
@@ -478,4 +478,12 @@ func TestRedisLogState(t *testing.T) {
 
 	expectNilLogState(t, rc, "")
 	expectNilLogState(t, rc, fmt.Sprintf("%s/a", log.ShortURL))
+
+	list, err := rc.GetAllLogStates()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(list) != 1 {
+		t.Errorf("Expected 1 log state: %+v", list)
+	}
 }

--- a/storage/types.go
+++ b/storage/types.go
@@ -70,6 +70,7 @@ type CertDatabase interface {
 	Cleanup() error
 	SaveLogState(aLogObj *CertificateLog) error
 	GetLogState(url *url.URL) (*CertificateLog, error)
+	GetAllLogStates() []*CertificateLog
 	Store(aCert *x509.Certificate, aIssuer *x509.Certificate, aURL string,
 		aEntryId int64) error
 	ListExpirationDates(aNotBefore time.Time) ([]ExpDate, error)
@@ -98,6 +99,7 @@ type RemoteCache interface {
 	KeysToChan(pattern string, c chan<- string) error
 	StoreLogState(aLogObj *CertificateLog) error
 	LoadLogState(aLogUrl string) (*CertificateLog, error)
+	GetAllLogStates() ([]*CertificateLog, error)
 }
 
 type Issuer struct {

--- a/storage/types.go
+++ b/storage/types.go
@@ -23,13 +23,14 @@ const (
 )
 
 type CertificateLog struct {
-	ShortURL      string    `db:"url"`           // URL to the log
-	MaxEntry      int64     `db:"maxEntry"`      // The most recent entryID logged
-	LastEntryTime time.Time `db:"lastEntryTime"` // Date when we completed the last update
+	ShortURL       string    `db:"url"`            // URL to the log
+	MaxEntry       int64     `db:"maxEntry"`       // The most recent entryID logged
+	LastEntryTime  time.Time `db:"lastEntryTime"`  // Date of the most recently logged entry
+	LastUpdateTime time.Time `db:"lastUpdateTime"` // Date when we completed the last update
 }
 
 func (o *CertificateLog) String() string {
-	return fmt.Sprintf("[%s] MaxEntry=%d, LastEntryTime=%s", o.ShortURL, o.MaxEntry, o.LastEntryTime)
+	return fmt.Sprintf("[%s] MaxEntry=%d, LastEntryTime=%s LastUpdateTime=%s", o.ShortURL, o.MaxEntry, o.LastEntryTime, o.LastUpdateTime)
 }
 
 func CertificateLogIDFromShortURL(shortURL string) string {

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -171,12 +171,13 @@ func TestSerialID(t *testing.T) {
 
 func TestLog(t *testing.T) {
 	log := CertificateLog{
-		ShortURL:      "log.example.com/2525",
-		MaxEntry:      math.MaxInt64,
-		LastEntryTime: time.Date(2525, time.May, 20, 19, 21, 54, 39, time.UTC),
+		ShortURL:       "log.example.com/2525",
+		MaxEntry:       math.MaxInt64,
+		LastEntryTime:  time.Date(2525, time.May, 20, 19, 21, 54, 39, time.UTC),
+		LastUpdateTime: time.Date(3000, time.December, 31, 23, 55, 59, 0, time.UTC),
 	}
 
-	expectedString := "[log.example.com/2525] MaxEntry=9223372036854775807, LastEntryTime=2525-05-20 19:21:54.000000039 +0000 UTC"
+	expectedString := "[log.example.com/2525] MaxEntry=9223372036854775807, LastEntryTime=2525-05-20 19:21:54.000000039 +0000 UTC LastUpdateTime=3000-12-31 23:55:59 +0000 UTC"
 	if log.String() != expectedString {
 		t.Errorf("Expecting %s but got %s", expectedString, log.String())
 	}


### PR DESCRIPTION
This is for https://github.com/mozilla/crlite/issues/55 and fixes #40 .

Adds a liveness check at a configurable port, default :8080, which returns `200 OK` if entries were obtained within `2 * the configured Polling Delay Mean` and returns `500` otherwise.