### PR TITLE
Provide a higher-performance health check (#42)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type CTConfig struct {
 	OutputRefreshPeriod *string
 	Config              *string
 	StackdriverMetrics  *bool
+	HealthAddr          *string
 }
 
 func confInt(p *int, section *ini.Section, key string, def int) {
@@ -132,6 +133,7 @@ func NewCTConfig() *CTConfig {
 		CertPath:            new(string),
 		GoogleProjectId:     new(string),
 		StackdriverMetrics:  new(bool),
+		HealthAddr:          new(string),
 		RedisHost:           new(string),
 		RedisTimeout:        new(string),
 		SavePeriod:          new(string),
@@ -194,6 +196,7 @@ func (c *CTConfig) Init() {
 	confString(c.OutputRefreshPeriod, section, "outputRefreshPeriod", "125ms")
 	confString(c.StatsRefreshPeriod, section, "statsRefreshPeriod", "10m")
 	confBool(c.StackdriverMetrics, section, "stackdriverMetrics", false)
+	confString(c.HealthAddr, section, "healthAddr", ":8080")
 
 	// Finally, CLI flags override
 	if flagOffset > 0 {
@@ -233,4 +236,5 @@ func (c *CTConfig) Usage() {
 	fmt.Println("statsRefreshPeriod = Period between stats being dumped to stderr")
 	fmt.Println("stackdriverMetrics = true if should log to StackDriver, requires googleProjectId")
 	fmt.Println("redisTimeout = Timeout for operations from Redis, e.g. 10s")
+	fmt.Println("healthAddr = Address to host the /health information http endpoint, e.g. localhost:8080")
 }

--- a/storage/types.go
+++ b/storage/types.go
@@ -23,13 +23,14 @@ const (
 )
 
 type CertificateLog struct {
-	ShortURL      string    `db:"url"`           // URL to the log
-	MaxEntry      int64     `db:"maxEntry"`      // The most recent entryID logged
-	LastEntryTime time.Time `db:"lastEntryTime"` // Date when we completed the last update
+	ShortURL       string    `db:"url"`            // URL to the log
+	MaxEntry       int64     `db:"maxEntry"`       // The most recent entryID logged
+	LastEntryTime  time.Time `db:"lastEntryTime"`  // Date of the most recently logged entry
+	LastUpdateTime time.Time `db:"lastUpdateTime"` // Date when we completed the last update
 }
 
 func (o *CertificateLog) String() string {
-	return fmt.Sprintf("[%s] MaxEntry=%d, LastEntryTime=%s", o.ShortURL, o.MaxEntry, o.LastEntryTime)
+	return fmt.Sprintf("[%s] MaxEntry=%d, LastEntryTime=%s LastUpdateTime=%s", o.ShortURL, o.MaxEntry, o.LastEntryTime, o.LastUpdateTime)
 }
 
 func CertificateLogIDFromShortURL(shortURL string) string {

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -171,12 +171,13 @@ func TestSerialID(t *testing.T) {
 
 func TestLog(t *testing.T) {
 	log := CertificateLog{
-		ShortURL:      "log.example.com/2525",
-		MaxEntry:      math.MaxInt64,
-		LastEntryTime: time.Date(2525, time.May, 20, 19, 21, 54, 39, time.UTC),
+		ShortURL:       "log.example.com/2525",
+		MaxEntry:       math.MaxInt64,
+		LastEntryTime:  time.Date(2525, time.May, 20, 19, 21, 54, 39, time.UTC),
+		LastUpdateTime: time.Date(3000, time.December, 31, 23, 55, 59, 0, time.UTC),
 	}
 
-	expectedString := "[log.example.com/2525] MaxEntry=9223372036854775807, LastEntryTime=2525-05-20 19:21:54.000000039 +0000 UTC"
+	expectedString := "[log.example.com/2525] MaxEntry=9223372036854775807, LastEntryTime=2525-05-20 19:21:54.000000039 +0000 UTC LastUpdateTime=3000-12-31 23:55:59 +0000 UTC"
 	if log.String() != expectedString {
 		t.Errorf("Expecting %s but got %s", expectedString, log.String())
 	}


### PR DESCRIPTION
This changes the health check from #41 from a database-check to a local
timestamp updated by all the CT downloader threads.